### PR TITLE
GH-34945: [Docs][C++] update cmake_mini_version

### DIFF
--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -45,7 +45,9 @@ This minimal ``CMakeLists.txt`` file compiles a ``my_example.cc`` source
 file into an executable linked with the Arrow C++ shared library:
 
 .. code-block:: cmake
-
+   
+   cmake_minimum_required(VERSION 3.16)
+   
    project(MyExample)
 
    find_package(Arrow REQUIRED)


### PR DESCRIPTION
1. add cmake_minimum_required(3.16) .
2. the version is based on #34921.